### PR TITLE
Use full GitHub profile URLs for username links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Jay has set the http response headers for the ukhdr directory and subdirectories
 Please contact any of those listed on attributions below.
 
 # Attribution
-Code co-authored by [Eric Weig](@libmanuk) and [Neal Powers](@nealium104) with contributions by [MLE Slone](@cokernel).
+Code co-authored by [Eric Weig](https://github.com/libmanuk/) and [Neal Powers](https://github.com/Nealium104/) with contributions by [MLE Slone](https://github.com/cokernel/).


### PR DESCRIPTION
GitHub does not autolink user profiles in Markdown.

In particular, if README.md in branch dev includes the following:

```markdown
[Ex Ample](@example)
```

Then the link actually rendered is:

```
https://github.com/uklibraries/UKL_HeaderFooter/blob/dev/@example
```

I've corrected the links in README.md to use full URLs for GitHub profiles.